### PR TITLE
Add treemap legend and explorer integration improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The Folder Map Visualizer is a Tkinter desktop application for exploring the str
 ## Features
 
 - Background directory scanner that keeps the UI responsive while traversing very large folder trees.
-- Treemap visualisation sized by file size and coloured by age, with tooltips and click-to-open support.
+- Treemap visualisation sized by file size and coloured by age, with tooltips, a colour bar legend, and click-to-open support.
 - Filtering controls for minimum file size, file extensions, and maximum file age.
 - Multiple sort options (size, name, modification time) and configurable rectangle limit for performance with huge folders.
 - Dark mode toggle, Matplotlib navigation toolbar, and image export (PNG, SVG, PDF).

--- a/folder_map_visualizer/treemap.py
+++ b/folder_map_visualizer/treemap.py
@@ -13,6 +13,8 @@ from typing import Callable, Dict, Iterable, List, Optional
 import matplotlib as mpl
 import matplotlib.cm as cm
 from matplotlib.axes import Axes
+from matplotlib.colorbar import Colorbar
+from matplotlib.offsetbox import AnchoredText
 from matplotlib.patches import Rectangle
 import squarify
 
@@ -57,6 +59,8 @@ class TreemapVisualizer:
         )
         self._annotation.set_visible(False)
         self._theme = "light"
+        self._colorbar: Optional[Colorbar] = None
+        self._size_legend: Optional[AnchoredText] = None
         canvas = self.figure.canvas
         canvas.mpl_connect("motion_notify_event", self._on_move)
         canvas.mpl_connect("button_press_event", self._on_click)
@@ -70,10 +74,23 @@ class TreemapVisualizer:
         self._annotation.get_bbox_patch().set_facecolor("#333333" if theme == "dark" else "#ffffff")
         self._annotation.get_bbox_patch().set_edgecolor("#eeeeee" if theme == "dark" else "#666666")
         self._annotation.set_color(fg)
+        if self._colorbar is not None:
+            if self._colorbar.outline is not None:
+                self._colorbar.outline.set_edgecolor(fg)
+            self._colorbar.ax.yaxis.label.set_color(fg)
+            self._colorbar.ax.tick_params(colors=fg)
+            for spine in self._colorbar.ax.spines.values():
+                spine.set_edgecolor(fg)
+        if self._size_legend is not None:
+            self._size_legend.txt.set_color(fg)
         self.figure.canvas.draw_idle()
 
     def draw(self, items: Iterable[TreemapItem]) -> None:
         self.ax.clear()
+        if self._colorbar is not None:
+            self._colorbar.remove()
+            self._colorbar = None
+        self._size_legend = None
         items_list = [item for item in items if item.size > 0]
         if not items_list:
             self.ax.text(
@@ -94,15 +111,19 @@ class TreemapVisualizer:
         rects = squarify.squarify(norm_area, 0, 0, 100, 100)
 
         ages = [item.age_seconds for item in items_list if item.age_seconds is not None]
-        max_age = max(ages) if ages else 1
-        norm = mpl.colors.Normalize(vmin=0, vmax=max_age)
-        cmap = cm.get_cmap("viridis" if self._theme == "light" else "plasma")
+        ages_days = [age / 86400 for age in ages]
+        max_age_days = max(ages_days) if ages_days else 1
+        norm = mpl.colors.Normalize(vmin=0, vmax=max_age_days)
+        cmap_name = "viridis" if self._theme == "light" else "plasma"
+        cmap_obj = cm.get_cmap(cmap_name)
 
         self._patch_metadata.clear()
         self.ax.set_axis_off()
 
         for rect, item in zip(rects, items_list):
-            color = "#555555" if item.age_seconds is None else cmap(norm(item.age_seconds))
+            color = "#555555"
+            if item.age_seconds is not None:
+                color = cmap_obj(norm((item.age_seconds or 0) / 86400))
             patch = Rectangle((rect["x"], rect["y"]), rect["dx"], rect["dy"], facecolor=color, edgecolor="#202020", linewidth=0.5)
             self.ax.add_patch(patch)
             self._patch_metadata[patch] = item
@@ -123,6 +144,29 @@ class TreemapVisualizer:
         self.ax.set_xlim(0, 100)
         self.ax.set_ylim(0, 100)
         self.ax.invert_yaxis()
+
+        if ages_days:
+            scalar_mappable = cm.ScalarMappable(norm=norm, cmap=cmap_obj)
+            scalar_mappable.set_array([])
+            self._colorbar = self.figure.colorbar(scalar_mappable, ax=self.ax, fraction=0.046, pad=0.02)
+            label_color = "#f0f0f0" if self._theme == "dark" else "#222222"
+            self._colorbar.set_label("File age (days)", color=label_color)
+            tick_labels = self._colorbar.get_ticks()
+            self._colorbar.set_ticks(tick_labels)
+            self._colorbar.ax.tick_params(colors=label_color)
+            for spine in self._colorbar.ax.spines.values():
+                spine.set_edgecolor(label_color)
+
+        legend_text_color = "#f0f0f0" if self._theme == "dark" else "#222222"
+        self._size_legend = AnchoredText(
+            "Area ∝ file size",
+            loc="lower left",
+            prop=dict(color=legend_text_color, size=9),
+            frameon=False,
+            pad=0.3,
+        )
+        self.ax.add_artist(self._size_legend)
+
         self.figure.canvas.draw_idle()
 
     def _find_patch(self, event) -> Optional[Rectangle]:
@@ -217,13 +261,25 @@ def build_treemap_items(
 def open_path_in_explorer(path: str) -> None:
     """Open ``path`` in the platform specific file explorer."""
 
+    target = Path(path)
+    if not target.exists():
+        return
+
     try:
+        target_str = str(target)
         if sys.platform.startswith("win"):
-            os.startfile(path)  # type: ignore[attr-defined]
+            if target.is_dir():
+                os.startfile(target_str)  # type: ignore[attr-defined]
+            else:
+                subprocess.Popen(["explorer", f'/select,"{target_str}"'])
         elif sys.platform == "darwin":
-            subprocess.Popen(["open", path])
+            if target.is_dir():
+                subprocess.Popen(["open", target_str])
+            else:
+                subprocess.Popen(["open", "-R", target_str])
         else:
-            subprocess.Popen(["xdg-open", path])
+            directory = target if target.is_dir() else target.parent
+            subprocess.Popen(["xdg-open", str(directory)])
     except Exception:
         # The UI layer handles error reporting if needed.
         pass


### PR DESCRIPTION
## Summary
- add an automatic colour bar legend and size annotation to the treemap with theme-aware styling
- normalise age values to days for accurate colouring and keep legends in sync when the theme changes
- improve explorer integration so files are revealed in their containing folder across platforms and document the legend enhancement

## Testing
- python -m compileall folder_map_visualizer/treemap.py

------
https://chatgpt.com/codex/tasks/task_e_68e3a27cc4748332a9b3e3c19c8ce6b3