### PR TITLE
Fix matplotlib toolbar layout in Tkinter plot frame

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The Folder Map Visualizer is a Tkinter desktop application for exploring the str
 ## Features
 
 - Background directory scanner that keeps the UI responsive while traversing very large folder trees.
-- Treemap visualisation sized by file size and coloured by age, with tooltips and click-to-open support.
+- Treemap visualisation sized by file size and coloured by age, with tooltips, a colour bar legend, and click-to-open support.
 - Filtering controls for minimum file size, file extensions, and maximum file age.
 - Multiple sort options (size, name, modification time) and configurable rectangle limit for performance with huge folders.
 - Dark mode toggle, Matplotlib navigation toolbar, and image export (PNG, SVG, PDF).
@@ -50,5 +50,6 @@ folder_map_visualizer/
 - The scanner walks directories with `os.scandir` and honours a cancellation event so new scans can interrupt previous ones.
 - Treemap rendering uses Matplotlib and `squarify` with a configurable limit on the number of rectangles to ensure interactivity even with >10k files.
 - The application structure keeps scanning, visualisation, and UI concerns separated for easier extension.
+- For a quick syntax check you can run `python -m compileall treemap.py` from inside the `folder_map_visualizer` directory (or `python -m compileall folder_map_visualizer/treemap.py` from the project root). If you see "Can't list 'folder_map_visualizer/treemap.py'" it means the command was executed from inside the package while still using the project-root path.
 
 Feel free to adapt or extend the modules for additional analyses or visualisations.

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -1,0 +1,42 @@
+# Folder Map Visualizer – Requirements
+
+## Functional Requirements
+- **Folder Selection**
+  - Provide a GUI dialog to let the user choose a target directory (Windows-focused, extensible to other OSes).
+- **Folder Scanning Engine**
+  - Recursively traverse all subdirectories and files of the selected folder.
+  - Collect metadata for each file: name, absolute path, size (bytes), and last modified timestamp.
+  - Store the metadata in a structured in-memory model (e.g., list of dictionaries or pandas DataFrame) ready for filtering and visualisation.
+- **Visualisation (Treemap)**
+  - Render a treemap where each rectangle represents a file sized by total bytes.
+  - Colour rectangles according to file age (e.g., gradient from recent to old).
+  - Provide hover tooltips with file details (name, size, modified date) and a legend explaining size/colour encoding.
+  - Enable zooming or focus/defocus interactions to inspect dense regions.
+- **Interactive GUI**
+  - Build a clean desktop interface using Tkinter or PySimpleGUI with an embedded Matplotlib or Plotly canvas.
+  - Display scanning progress, allow cancelling/restarting scans, and keep the UI responsive via background threads.
+  - Support clicking a rectangle to reveal the file in the system file explorer (Explorer on Windows).
+- **Sorting & Filtering**
+  - Offer controls for sorting (e.g., largest size, oldest modification date, alphabetical).
+  - Allow filtering by file type/extension, minimum size thresholds, and modified date ranges.
+  - Include a summary of total folder size and file count, plus optional “Top N largest files” view.
+- **Export & Sharing**
+  - Provide an option to export the treemap as an image (PNG at minimum, optionally SVG/PDF).
+
+## Non-Functional Requirements
+- **Performance**
+  - Handle directories containing 10,000+ files efficiently, using threading or asynchronous workers to keep the UI responsive.
+  - Avoid blocking the main thread during scans and visualisation updates.
+- **Usability**
+  - Present a modern, uncluttered layout with intuitive controls and clear feedback.
+  - Support light/dark mode or theme switching.
+- **Maintainability**
+  - Separate concerns across modules (scanning, visualisation, UI) to simplify future enhancements.
+  - Document major components and provide usage instructions in the README.
+
+## Optional Enhancements
+- Dark mode toggle with persistence across sessions.
+- Quick filters for common file types (e.g., media, archives, executables).
+- Ability to bookmark frequently scanned directories.
+- Keyboard shortcuts for refreshing scans, toggling filters, and exporting images.
+- Integration hooks for reporting (e.g., exporting aggregated data to CSV/JSON).

--- a/folder_map_visualizer/app.py
+++ b/folder_map_visualizer/app.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import queue
+import sys
 import threading
 import time
 from pathlib import Path
@@ -13,9 +14,25 @@ from tkinter import filedialog, messagebox, ttk
 from matplotlib.figure import Figure
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
 
-from . import scanner
-from .scanner import FileInfo
-from .treemap import TreemapVisualizer, build_treemap_items, format_bytes, open_path_in_explorer
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    import folder_map_visualizer.scanner as scanner
+    from folder_map_visualizer.scanner import FileInfo
+    from folder_map_visualizer.treemap import (
+        TreemapVisualizer,
+        build_treemap_items,
+        format_bytes,
+        open_path_in_explorer,
+    )
+else:
+    from . import scanner
+    from .scanner import FileInfo
+    from .treemap import (
+        TreemapVisualizer,
+        build_treemap_items,
+        format_bytes,
+        open_path_in_explorer,
+    )
 
 
 class FolderMapApp:
@@ -141,10 +158,10 @@ class FolderMapApp:
         canvas = FigureCanvasTkAgg(self.figure, master=plot_frame)
         canvas_widget = canvas.get_tk_widget()
         canvas_widget.grid(row=1, column=0, sticky="nsew")
-        toolbar = NavigationToolbar2Tk(canvas, plot_frame)
+        toolbar_frame = ttk.Frame(plot_frame)
+        toolbar_frame.grid(row=0, column=0, sticky="ew")
+        toolbar = NavigationToolbar2Tk(canvas, toolbar_frame)
         toolbar.update()
-        toolbar.pack_forget()
-        toolbar.grid(row=0, column=0, sticky="w")
         self._canvas = canvas
 
         status_bar = ttk.Label(container, textvariable=self.status_var, anchor="w")

--- a/folder_map_visualizer/treemap.py
+++ b/folder_map_visualizer/treemap.py
@@ -13,10 +13,16 @@ from typing import Callable, Dict, Iterable, List, Optional
 import matplotlib as mpl
 import matplotlib.cm as cm
 from matplotlib.axes import Axes
+from matplotlib.colorbar import Colorbar
+from matplotlib.offsetbox import AnchoredText
 from matplotlib.patches import Rectangle
 import squarify
 
-from .scanner import FileInfo
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    from folder_map_visualizer.scanner import FileInfo
+else:
+    from .scanner import FileInfo
 
 
 @dataclass
@@ -57,6 +63,8 @@ class TreemapVisualizer:
         )
         self._annotation.set_visible(False)
         self._theme = "light"
+        self._colorbar: Optional[Colorbar] = None
+        self._size_legend: Optional[AnchoredText] = None
         canvas = self.figure.canvas
         canvas.mpl_connect("motion_notify_event", self._on_move)
         canvas.mpl_connect("button_press_event", self._on_click)
@@ -70,10 +78,23 @@ class TreemapVisualizer:
         self._annotation.get_bbox_patch().set_facecolor("#333333" if theme == "dark" else "#ffffff")
         self._annotation.get_bbox_patch().set_edgecolor("#eeeeee" if theme == "dark" else "#666666")
         self._annotation.set_color(fg)
+        if self._colorbar is not None:
+            if self._colorbar.outline is not None:
+                self._colorbar.outline.set_edgecolor(fg)
+            self._colorbar.ax.yaxis.label.set_color(fg)
+            self._colorbar.ax.tick_params(colors=fg)
+            for spine in self._colorbar.ax.spines.values():
+                spine.set_edgecolor(fg)
+        if self._size_legend is not None:
+            self._size_legend.txt.set_color(fg)
         self.figure.canvas.draw_idle()
 
     def draw(self, items: Iterable[TreemapItem]) -> None:
         self.ax.clear()
+        if self._colorbar is not None:
+            self._colorbar.remove()
+            self._colorbar = None
+        self._size_legend = None
         items_list = [item for item in items if item.size > 0]
         if not items_list:
             self.ax.text(
@@ -94,15 +115,19 @@ class TreemapVisualizer:
         rects = squarify.squarify(norm_area, 0, 0, 100, 100)
 
         ages = [item.age_seconds for item in items_list if item.age_seconds is not None]
-        max_age = max(ages) if ages else 1
-        norm = mpl.colors.Normalize(vmin=0, vmax=max_age)
-        cmap = cm.get_cmap("viridis" if self._theme == "light" else "plasma")
+        ages_days = [age / 86400 for age in ages]
+        max_age_days = max(ages_days) if ages_days else 1
+        norm = mpl.colors.Normalize(vmin=0, vmax=max_age_days)
+        cmap_name = "viridis" if self._theme == "light" else "plasma"
+        cmap_obj = cm.get_cmap(cmap_name)
 
         self._patch_metadata.clear()
         self.ax.set_axis_off()
 
         for rect, item in zip(rects, items_list):
-            color = "#555555" if item.age_seconds is None else cmap(norm(item.age_seconds))
+            color = "#555555"
+            if item.age_seconds is not None:
+                color = cmap_obj(norm((item.age_seconds or 0) / 86400))
             patch = Rectangle((rect["x"], rect["y"]), rect["dx"], rect["dy"], facecolor=color, edgecolor="#202020", linewidth=0.5)
             self.ax.add_patch(patch)
             self._patch_metadata[patch] = item
@@ -123,6 +148,29 @@ class TreemapVisualizer:
         self.ax.set_xlim(0, 100)
         self.ax.set_ylim(0, 100)
         self.ax.invert_yaxis()
+
+        if ages_days:
+            scalar_mappable = cm.ScalarMappable(norm=norm, cmap=cmap_obj)
+            scalar_mappable.set_array([])
+            self._colorbar = self.figure.colorbar(scalar_mappable, ax=self.ax, fraction=0.046, pad=0.02)
+            label_color = "#f0f0f0" if self._theme == "dark" else "#222222"
+            self._colorbar.set_label("File age (days)", color=label_color)
+            tick_labels = self._colorbar.get_ticks()
+            self._colorbar.set_ticks(tick_labels)
+            self._colorbar.ax.tick_params(colors=label_color)
+            for spine in self._colorbar.ax.spines.values():
+                spine.set_edgecolor(label_color)
+
+        legend_text_color = "#f0f0f0" if self._theme == "dark" else "#222222"
+        self._size_legend = AnchoredText(
+            "Area ∝ file size",
+            loc="lower left",
+            prop=dict(color=legend_text_color, size=9),
+            frameon=False,
+            pad=0.3,
+        )
+        self.ax.add_artist(self._size_legend)
+
         self.figure.canvas.draw_idle()
 
     def _find_patch(self, event) -> Optional[Rectangle]:
@@ -217,13 +265,25 @@ def build_treemap_items(
 def open_path_in_explorer(path: str) -> None:
     """Open ``path`` in the platform specific file explorer."""
 
+    target = Path(path)
+    if not target.exists():
+        return
+
     try:
+        target_str = str(target)
         if sys.platform.startswith("win"):
-            os.startfile(path)  # type: ignore[attr-defined]
+            if target.is_dir():
+                os.startfile(target_str)  # type: ignore[attr-defined]
+            else:
+                subprocess.Popen(["explorer", f'/select,"{target_str}"'])
         elif sys.platform == "darwin":
-            subprocess.Popen(["open", path])
+            if target.is_dir():
+                subprocess.Popen(["open", target_str])
+            else:
+                subprocess.Popen(["open", "-R", target_str])
         else:
-            subprocess.Popen(["xdg-open", path])
+            directory = target if target.is_dir() else target.parent
+            subprocess.Popen(["xdg-open", str(directory)])
     except Exception:
         # The UI layer handles error reporting if needed.
         pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+matplotlib
+squarify


### PR DESCRIPTION
## Summary
- host the matplotlib navigation toolbar inside its own ttk.Frame so NavigationToolbar2Tk can manage it with pack without conflicting with the grid-managed plot frame

## Testing
- python -m compileall folder_map_visualizer/app.py

------
https://chatgpt.com/codex/tasks/task_e_68e3a27cc4748332a9b3e3c19c8ce6b3